### PR TITLE
Use new style exceptions in both Python 2 and Python 3

### DIFF
--- a/submodules/pywerview/requester.py
+++ b/submodules/pywerview/requester.py
@@ -72,7 +72,7 @@ class LDAPRequester():
                                                   base_dn, self._domain_controller)
             ldap_connection.login(self._user, self._password, self._domain,
                                   self._lmhash, self._nthash)
-        except (ldap.LDAPSessionError, e):
+        except ldap.LDAPSessionError as e:
             if str(e).find('strongerAuthRequired') >= 0:
                 # We need to try SSL
                 ldap_connection = ldap.LDAPConnection('ldaps://{}'.format(self._domain_controller),
@@ -81,7 +81,7 @@ class LDAPRequester():
                                       self._lmhash, self._nthash)
             else:
                 raise e
-        except (socket.error, e):
+        except socket.error as e:
             return
 
         self._ldap_connection = ldap_connection


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.